### PR TITLE
lssystemstats collector to be forward compatible with new version api

### DIFF
--- a/collector/system_stats_collector.go
+++ b/collector/system_stats_collector.go
@@ -163,8 +163,10 @@ func (c *systemStatsCollector) Collect(sClient utils.SpectrumClient, ch chan<- p
 
 	systemStats := gjson.Parse(systemStatsResp).Array()
 	for i, systemStat := range systemStats {
-		ch <- prometheus.MustNewConstMetric(metrics[i], prometheus.GaugeValue, systemStat.Get("stat_current").Float(), labelvalues...)
-
+		// ignore the fields greater than 49
+		if i < 49 {
+			ch <- prometheus.MustNewConstMetric(metrics[i], prometheus.GaugeValue, systemStat.Get("stat_current").Float(), labelvalues...)
+		}
 	}
 	logger.Debugln("exit SystemStats collector")
 	return nil


### PR DESCRIPTION
# Pull Request Info

## Change Description

> The 'lssystemstats' collector is not forward compatible with new version of 'lssystemstats' api.
> For current version of the lssystemstats api, the collector only support 49 fields.

## Related Issue

> #20 

## Test Result

> Provide test methodology, environment, and results if applicable.

- [ ] Unit Test

- [ ] Integration Test
