### PR TITLE
fix: Honor VerifyCert setting

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -108,6 +108,7 @@ func NewSVCCollector(targets []utils.Target, tokenCaches map[string]*utils.AuthT
 				UserName:       t.Userid,
 				Password:       t.Password,
 				IpAddress:      t.IpAddress,
+				VerifyCert:     t.VerifyCert,
 				AuthTokenCache: tokenCaches[t.IpAddress],
 				AuthTokenMutex: tokenMutexes[t.IpAddress],
 				ColCounter:     colCounters[t.IpAddress],

--- a/collector_s/collector.go
+++ b/collector_s/collector.go
@@ -108,6 +108,7 @@ func NewSVCCollector(targets []utils.Target, tokenCaches map[string]*utils.AuthT
 				UserName:       t.Userid,
 				Password:       t.Password,
 				IpAddress:      t.IpAddress,
+				VerifyCert:     t.VerifyCert,
 				AuthTokenCache: tokenCaches[t.IpAddress],
 				AuthTokenMutex: tokenMutexes[t.IpAddress],
 				ColCounter:     colCounters[t.IpAddress],

--- a/utils/config.go
+++ b/utils/config.go
@@ -28,9 +28,10 @@ type Config struct {
 }
 
 type Target struct {
-	IpAddress string `yaml:"ipAddress"`
-	Userid    string `yaml:"userid"`
-	Password  string `yaml:"password"`
+	IpAddress  string `yaml:"ipAddress"`
+	Userid     string `yaml:"userid"`
+	Password   string `yaml:"password"`
+	VerifyCert bool   `yaml:"verifyCert"`
 }
 
 type Label struct {

--- a/utils/spectrumClient.go
+++ b/utils/spectrumClient.go
@@ -165,7 +165,7 @@ func (s *SpectrumClient) retrieveAuthToken() (authToken string, err error) {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       &tls.Config{InsecureSkipVerify: false, MinVersion: tls.VersionTLS12},
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: !s.VerifyCert, MinVersion: tls.VersionTLS12},
 	},
 		Timeout: 45 * time.Second,
 	}
@@ -205,7 +205,7 @@ func (s *SpectrumClient) CallSpectrumAPI(restCmd string, autoRenewToken bool) (b
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       &tls.Config{InsecureSkipVerify: false, MinVersion: tls.VersionTLS12},
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: !s.VerifyCert, MinVersion: tls.VersionTLS12},
 	},
 		Timeout: 45 * time.Second}
 	// New POST request


### PR DESCRIPTION
# Pull Request Info

Honor VerifyCert setting

Without this patch, the verifyCert setting does absolutely nothing. It is not even set or read.

## Related Issue

If you do not accept this patch, I will of course open an issue, but I thought this would get it fixed faster. 

## Test Result

Running against my IBM FlashSystem without a valid certificate works now.
