### PR TITLE
Handling of zero value error

### DIFF
--- a/utils/common.go
+++ b/utils/common.go
@@ -43,6 +43,11 @@ func ToBytes(s string) (uint64, error) {
 
 	i := strings.IndexFunc(s, unicode.IsLetter)
 
+	// Handling of zero value without any error
+	if s == "0" || s == "0.0" || s == "0.00" {
+		return 0, nil
+	}
+
 	if i == -1 {
 		return 0, errInvalidByteQuantity
 	}


### PR DESCRIPTION
# Pull Request Info

Handling of zero value error

> A brief summary of the change proposed in this pull request.

If value of any parameter of cli is zero then we are getting below. This change set is to fix this error

`
ERRO[0008] Converting capacity unit failed: byte quantity must be a positive integer with a unit of measurement like M, MB, MiB, G, GiB, or GB  component=spectrum_exporter source="mdiskgrp_collector.go:157"

ERRO[0008] Converting capacity unit failed: byte quantity must be a positive integer with a unit of measurement like M, MB, MiB, G, GiB, or GB  component=spectrum_exporter source="mdiskgrp_collector.go:169"

ERRO[0008] Converting capacity unit failed: byte quantity must be a positive integer with a unit of measurement like M, MB, MiB, G, GiB, or GB  component=spectrum_exporter source="mdiskgrp_collector.go:157"

ERRO[0008] Converting capacity unit failed: byte quantity must be a positive integer with a unit of measurement like M, MB, MiB, G, GiB, or GB  component=spectrum_exporter source="mdiskgrp_collector.go:169"

ERRO[0008] Converting capacity unit failed: byte quantity must be a positive integer with a unit of measurement like M, MB, MiB, G, GiB, or GB  component=spectrum_exporter source="mdiskgrp_collector.go:157"

ERRO[0008] Converting capacity unit failed: byte quantity must be a positive integer with a unit of measurement like M, MB, MiB, G, GiB, or GB  component=spectrum_exporter source="mdiskgrp_collector.go:169"

ERRO[0008] Converting capacity unit failed: byte quantity must be a positive integer with a unit of measurement like M, MB, MiB, G, GiB, or GB  component=spectrum_exporter source="system_collector.go:323"

ERRO[0008] Converting capacity unit failed: byte quantity must be a positive integer with a unit of measurement like M, MB, MiB, G, GiB, or GB  component=spectrum_exporter source="system_collector.go:323"

ERRO[0008] Converting capacity unit failed: byte quantity must be a positive integer with a unit of measurement like M, MB, MiB, G, GiB, or GB  component=spectrum_exporter source="system_collector.go:323"
`

> Provide the issue id related to the PR.

## Test Result

> Provide test methodology, environment, and results if applicable.

- [ ] Unit Test
Tested with prometheus exporter
- [ ] Integration Test

Tested integration with Prometheus and Grafana