### PR TITLE
Fix incorrect nodestats metric mapping

### DIFF
--- a/collector/node_stats_collector.go
+++ b/collector/node_stats_collector.go
@@ -23,7 +23,7 @@ import (
 const prefix_nodeStats = "spectrum_nodestats_"
 
 var (
-	nodeStats_metrics [46]*prometheus.Desc
+	nodeStats_metrics map[string]*prometheus.Desc
 )
 
 func init() {
@@ -39,69 +39,69 @@ func NewNodeStatsCollector() (Collector, error) {
 	if len(utils.ExtraLabelNames) > 0 {
 		labelnames = append(labelnames, utils.ExtraLabelNames...)
 	}
-	nodeStats_metrics = [46]*prometheus.Desc{
-		prometheus.NewDesc(prefix_nodeStats+"compression_cpu_pc", "The percentage of allocated CPU capacity that is used for compression.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"cpu_pc", "The percentage of allocated CPU capacity that is used for the system.", labelnames, nil),
+	nodeStats_metrics = map[string]*prometheus.Desc{
+		"compression_cpu_pc": prometheus.NewDesc(prefix_nodeStats+"compression_cpu_pc", "The percentage of allocated CPU capacity that is used for compression.", labelnames, nil),
+		"cpu_pc":             prometheus.NewDesc(prefix_nodeStats+"cpu_pc", "The percentage of allocated CPU capacity that is used for the system.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"fc_mb", "The total number of megabytes transferred per second (MBps) for Fibre Channel traffic on the system. This value includes host I/O and any bandwidth that is used for communication within the system.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"fc_io", "The total input/output (I/O) operations that are transferred per seconds for Fibre Channel traffic on the system. This value includes host I/O and any bandwidth that is used for communication within the system.", labelnames, nil),
+		"fc_mb": prometheus.NewDesc(prefix_nodeStats+"fc_mb", "The total number of megabytes transferred per second (MBps) for Fibre Channel traffic on the system. This value includes host I/O and any bandwidth that is used for communication within the system.", labelnames, nil),
+		"fc_io": prometheus.NewDesc(prefix_nodeStats+"fc_io", "The total input/output (I/O) operations that are transferred per seconds for Fibre Channel traffic on the system. This value includes host I/O and any bandwidth that is used for communication within the system.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"sas_mb", "The total number of megabytes transferred per second (MBps) for serial-attached SCSI (SAS) traffic on the system. This value includes host I/O and bandwidth that is used for background RAID activity.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"sas_io", "The total I/O operations that are transferred per second for SAS traffic on the system. This value includes host I/O and bandwidth that is used for background RAID activity.", labelnames, nil),
+		"sas_mb": prometheus.NewDesc(prefix_nodeStats+"sas_mb", "The total number of megabytes transferred per second (MBps) for serial-attached SCSI (SAS) traffic on the system. This value includes host I/O and bandwidth that is used for background RAID activity.", labelnames, nil),
+		"sas_io": prometheus.NewDesc(prefix_nodeStats+"sas_io", "The total I/O operations that are transferred per second for SAS traffic on the system. This value includes host I/O and bandwidth that is used for background RAID activity.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"iscsi_mb", "The total number of megabytes transferred per second (MBps) for iSCSI traffic on the system.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"iscsi_io", "The total I/O operations that are transferred per second for iSCSI traffic on the system.", labelnames, nil),
+		"iscsi_mb": prometheus.NewDesc(prefix_nodeStats+"iscsi_mb", "The total number of megabytes transferred per second (MBps) for iSCSI traffic on the system.", labelnames, nil),
+		"iscsi_io": prometheus.NewDesc(prefix_nodeStats+"iscsi_io", "The total I/O operations that are transferred per second for iSCSI traffic on the system.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"write_cache_pc", "The percentage of the write cache usage for the node.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"total_cache_pc", "The total percentage for both the write and read cache usage for the node.", labelnames, nil),
+		"write_cache_pc": prometheus.NewDesc(prefix_nodeStats+"write_cache_pc", "The percentage of the write cache usage for the node.", labelnames, nil),
+		"total_cache_pc": prometheus.NewDesc(prefix_nodeStats+"total_cache_pc", "The total percentage for both the write and read cache usage for the node.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"vdisk_mb", "The average number of megabytes transferred per second (MBps) for read and write operations to volumes during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"vdisk_io", "The average number of I/O operations that are transferred per second for read and write operations to volumes during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"vdisk_ms", "The average amount of time in milliseconds that the system takes to respond to read and write requests to volumes over the sample period.", labelnames, nil),
+		"vdisk_mb": prometheus.NewDesc(prefix_nodeStats+"vdisk_mb", "The average number of megabytes transferred per second (MBps) for read and write operations to volumes during the sample period.", labelnames, nil),
+		"vdisk_io": prometheus.NewDesc(prefix_nodeStats+"vdisk_io", "The average number of I/O operations that are transferred per second for read and write operations to volumes during the sample period.", labelnames, nil),
+		"vdisk_ms": prometheus.NewDesc(prefix_nodeStats+"vdisk_ms", "The average amount of time in milliseconds that the system takes to respond to read and write requests to volumes over the sample period.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"mdisk_mb", "The average number of megabytes transferred per second (MBps) for read and write operations to MDisks during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"mdisk_io", "The average number of I/O operations that are transferred per second for read and write operations to MDisks during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"mdisk_ms", "The average amount of time in milliseconds that the system takes to respond to read and write requests to MDisks over the sample period.", labelnames, nil),
+		"mdisk_mb": prometheus.NewDesc(prefix_nodeStats+"mdisk_mb", "The average number of megabytes transferred per second (MBps) for read and write operations to MDisks during the sample period.", labelnames, nil),
+		"mdisk_io": prometheus.NewDesc(prefix_nodeStats+"mdisk_io", "The average number of I/O operations that are transferred per second for read and write operations to MDisks during the sample period.", labelnames, nil),
+		"mdisk_ms": prometheus.NewDesc(prefix_nodeStats+"mdisk_ms", "The average amount of time in milliseconds that the system takes to respond to read and write requests to MDisks over the sample period.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"drive_mb", "The average number of megabytes transferred per second (MBps) for read and write operations to drives during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"drive_io", "The average number of I/O operations that are transferred per second for read and write operations to drives during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"drive_ms", "The average amount of time in milliseconds that the system takes to respond to read and write requests to drives over the sample period.", labelnames, nil),
+		"drive_mb": prometheus.NewDesc(prefix_nodeStats+"drive_mb", "The average number of megabytes transferred per second (MBps) for read and write operations to drives during the sample period.", labelnames, nil),
+		"drive_io": prometheus.NewDesc(prefix_nodeStats+"drive_io", "The average number of I/O operations that are transferred per second for read and write operations to drives during the sample period.", labelnames, nil),
+		"drive_ms": prometheus.NewDesc(prefix_nodeStats+"drive_ms", "The average amount of time in milliseconds that the system takes to respond to read and write requests to drives over the sample period.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"vdisk_r_mb", "The average number of megabytes transferred per second (MBps) for read operations to volumes during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"vdisk_r_io", "The average number of I/O operations that are transferred per second for read operations to volumes during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"vdisk_r_ms", "The average amount of time in milliseconds that the system takes to respond to read requests to volumes over the sample period.", labelnames, nil),
+		"vdisk_r_mb": prometheus.NewDesc(prefix_nodeStats+"vdisk_r_mb", "The average number of megabytes transferred per second (MBps) for read operations to volumes during the sample period.", labelnames, nil),
+		"vdisk_r_io": prometheus.NewDesc(prefix_nodeStats+"vdisk_r_io", "The average number of I/O operations that are transferred per second for read operations to volumes during the sample period.", labelnames, nil),
+		"vdisk_r_ms": prometheus.NewDesc(prefix_nodeStats+"vdisk_r_ms", "The average amount of time in milliseconds that the system takes to respond to read requests to volumes over the sample period.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"vdisk_w_mb", "The average number of megabytes transferred per second (MBps) for read and write operations to volumes during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"vdisk_w_io", "The average number of I/O operations that are transferred per second for write operations to volumes during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"vdisk_w_ms", "The average amount of time in milliseconds that the system takes to respond to write requests to volumes over the sample period.", labelnames, nil),
+		"vdisk_w_mb": prometheus.NewDesc(prefix_nodeStats+"vdisk_w_mb", "The average number of megabytes transferred per second (MBps) for read and write operations to volumes during the sample period.", labelnames, nil),
+		"vdisk_w_io": prometheus.NewDesc(prefix_nodeStats+"vdisk_w_io", "The average number of I/O operations that are transferred per second for write operations to volumes during the sample period.", labelnames, nil),
+		"vdisk_w_ms": prometheus.NewDesc(prefix_nodeStats+"vdisk_w_ms", "The average amount of time in milliseconds that the system takes to respond to write requests to volumes over the sample period.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"mdisk_r_mb", "The average number of megabytes transferred per second (MBps) for read operations to MDisks during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"mdisk_r_io", "The average number of I/O operations that are transferred per second for read operations to MDisks during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"mdisk_r_ms", "The average amount of time in milliseconds that the system takes to respond to read requests to MDisks over the sample period.", labelnames, nil),
+		"mdisk_r_mb": prometheus.NewDesc(prefix_nodeStats+"mdisk_r_mb", "The average number of megabytes transferred per second (MBps) for read operations to MDisks during the sample period.", labelnames, nil),
+		"mdisk_r_io": prometheus.NewDesc(prefix_nodeStats+"mdisk_r_io", "The average number of I/O operations that are transferred per second for read operations to MDisks during the sample period.", labelnames, nil),
+		"mdisk_r_ms": prometheus.NewDesc(prefix_nodeStats+"mdisk_r_ms", "The average amount of time in milliseconds that the system takes to respond to read requests to MDisks over the sample period.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"mdisk_w_mb", "The average number of megabytes transferred per second (MBps) for write operations to MDisks during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"mdisk_w_io", "TThe average number of I/O operations that are transferred per second for write operations to MDisks during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"mdisk_w_ms", "the average amount of time in milliseconds that the system takes to respond to write requests to MDisks over the sample period.", labelnames, nil),
+		"mdisk_w_mb": prometheus.NewDesc(prefix_nodeStats+"mdisk_w_mb", "The average number of megabytes transferred per second (MBps) for write operations to MDisks during the sample period.", labelnames, nil),
+		"mdisk_w_io": prometheus.NewDesc(prefix_nodeStats+"mdisk_w_io", "TThe average number of I/O operations that are transferred per second for write operations to MDisks during the sample period.", labelnames, nil),
+		"mdisk_w_ms": prometheus.NewDesc(prefix_nodeStats+"mdisk_w_ms", "the average amount of time in milliseconds that the system takes to respond to write requests to MDisks over the sample period.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"drive_r_mb", "The average number of megabytes transferred per second (MBps) for read operations to drives during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"drive_r_io", "The average number of I/O operations that are transferred per second for read operations to drives during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"drive_r_ms", "The average amount of time in milliseconds that the system takes to respond to read requests to drives over the sample period.", labelnames, nil),
+		"drive_r_mb": prometheus.NewDesc(prefix_nodeStats+"drive_r_mb", "The average number of megabytes transferred per second (MBps) for read operations to drives during the sample period.", labelnames, nil),
+		"drive_r_io": prometheus.NewDesc(prefix_nodeStats+"drive_r_io", "The average number of I/O operations that are transferred per second for read operations to drives during the sample period.", labelnames, nil),
+		"drive_r_ms": prometheus.NewDesc(prefix_nodeStats+"drive_r_ms", "The average amount of time in milliseconds that the system takes to respond to read requests to drives over the sample period.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"drive_w_mb", "The average number of megabytes transferred per second (MBps) for write operations to drives during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"drive_w_io", "The average number of I/O operations that are transferred per second for write operations to drives during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"drive_w_ms", "The average amount of time in milliseconds that the system takes to respond write requests to drives over the sample period.", labelnames, nil),
+		"drive_w_mb": prometheus.NewDesc(prefix_nodeStats+"drive_w_mb", "The average number of megabytes transferred per second (MBps) for write operations to drives during the sample period.", labelnames, nil),
+		"drive_w_io": prometheus.NewDesc(prefix_nodeStats+"drive_w_io", "The average number of I/O operations that are transferred per second for write operations to drives during the sample period.", labelnames, nil),
+		"drive_w_ms": prometheus.NewDesc(prefix_nodeStats+"drive_w_ms", "The average amount of time in milliseconds that the system takes to respond write requests to drives over the sample period.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"iplink_mb", "The average number of megabytes requested to be transferred per second (MBps) over the IP partnership link during the sample period. This value is calculated before any compression of the data takes place. This value does not include iSCSI host input/output (I/O) operations.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"iplink_io", "TThe total input/output (I/O) operations that are transferred per second for IP partnership traffic on the system.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"iplink_comp_mb", "The average number of compressed megabytes transferred per second (MBps) over the IP Replication link during the sample period. This value is calculated after any compression of |the data takes place. This value does not include iSCSI host I/O operations.", labelnames, nil),
+		"iplink_mb":      prometheus.NewDesc(prefix_nodeStats+"iplink_mb", "The average number of megabytes requested to be transferred per second (MBps) over the IP partnership link during the sample period. This value is calculated before any compression of the data takes place. This value does not include iSCSI host input/output (I/O) operations.", labelnames, nil),
+		"iplink_io":      prometheus.NewDesc(prefix_nodeStats+"iplink_io", "The total input/output (I/O) operations that are transferred per second for IP partnership traffic on the system.", labelnames, nil),
+		"iplink_comp_mb": prometheus.NewDesc(prefix_nodeStats+"iplink_comp_mb", "The average number of compressed megabytes transferred per second (MBps) over the IP Replication link during the sample period. This value is calculated after any compression of |the data takes place. This value does not include iSCSI host I/O operations.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"cloud_up_mb", "The average number of megabytes transferred per second (Mbps) for upload operations to a cloud account during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"cloud_up_ms", "The average amount of time (in milliseconds) it takes for the system to respond to upload requests to a cloud account during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"cloud_down_mb", "The average number of Mbps for download operations to a cloud account during the sample period.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"cloud_down_ms", "The average amount of time (in milliseconds) it takes for the system to respond to download requests to a cloud account during the sample period.", labelnames, nil),
+		"cloud_up_mb":   prometheus.NewDesc(prefix_nodeStats+"cloud_up_mb", "The average number of megabytes transferred per second (Mbps) for upload operations to a cloud account during the sample period.", labelnames, nil),
+		"cloud_up_ms":   prometheus.NewDesc(prefix_nodeStats+"cloud_up_ms", "The average amount of time (in milliseconds) it takes for the system to respond to upload requests to a cloud account during the sample period.", labelnames, nil),
+		"cloud_down_mb": prometheus.NewDesc(prefix_nodeStats+"cloud_down_mb", "The average number of Mbps for download operations to a cloud account during the sample period.", labelnames, nil),
+		"cloud_down_ms": prometheus.NewDesc(prefix_nodeStats+"cloud_down_ms", "The average amount of time (in milliseconds) it takes for the system to respond to download requests to a cloud account during the sample period.", labelnames, nil),
 
-		prometheus.NewDesc(prefix_nodeStats+"iser_mb", "The total number of megabytes transferred per second (MBps) for iSER traffic on the system.", labelnames, nil),
-		prometheus.NewDesc(prefix_nodeStats+"iser_io", "The total I/O operations that are transferred per second for iSER traffic on the system.", labelnames, nil),
+		"iser_mb": prometheus.NewDesc(prefix_nodeStats+"iser_mb", "The total number of megabytes transferred per second (MBps) for iSER traffic on the system.", labelnames, nil),
+		"iser_io": prometheus.NewDesc(prefix_nodeStats+"iser_io", "The total I/O operations that are transferred per second for iSER traffic on the system.", labelnames, nil),
 	}
 
 	return &nodeStatsCollector{}, nil
@@ -183,14 +183,32 @@ func (c *nodeStatsCollector) Collect(sClient utils.SpectrumClient, ch chan<- pro
 	// ]
 
 	nodeStatsArray := gjson.Parse(nodeStatsResp).Array()
-	nodesNumber := len(nodeStatsArray) / len(nodeStats_metrics)
 
-	for i, nodeStats_metric := range nodeStats_metrics {
-		for node := 0; node < nodesNumber; node++ {
-			index := len(nodeStats_metrics)*node + i
-			labelvalues := []string{sClient.Hostname, nodeStatsArray[index].Get("node_name").String()}
-			ch <- prometheus.MustNewConstMetric(nodeStats_metric, prometheus.GaugeValue, nodeStatsArray[index].Get("stat_current").Float(), labelvalues...)
+	labelBase := []string{sClient.Hostname}
+	if len(utils.ExtraLabelValues) > 0 {
+		labelBase = append(labelBase, utils.ExtraLabelValues...)
+	}
+
+	for _, stat := range nodeStatsArray {
+		statName := stat.Get("stat_name").String()
+		value := stat.Get("stat_current").Float()
+		nodeName := stat.Get("node_name").String()
+
+		desc, ok := nodeStats_metrics[statName]
+		if !ok {
+			// Unknown or new lsnodestats parameter --> safely ignored
+			logger.Debugln("lsnodestats: stats parameter ignored %s", statName)
+			continue
 		}
+
+		labelvalues := append(labelBase, nodeName)
+
+		ch <- prometheus.MustNewConstMetric(
+			desc,
+			prometheus.GaugeValue,
+			value,
+			labelvalues...,
+		)
 	}
 	logger.Debugln("exit NodeStats collector")
 	return nil


### PR DESCRIPTION
Signed-off-by: Ajinkya Nanavati <ananava1@in.ibm.com>

# Pull Request Info

## Change Description

Fixed incorrect nodestats statistics data exposed by the Prometheus exporter.
The change corrects metric mappings and ensures accurate reporting

## Related Issue
Fix incorrect node stats metric mapping


## Test Result

> Provide test methodology, environment, and results if applicable.

- [ ] Unit Test
Deployed the updated exporter in a test environment connected to an IBM Spectrum Virtualize cluster
Verified metric stability across multiple scrape intervals
No regression observed in metric availability or scrape performance

- [ ] Integration Test
Grafana dashboards render accurate and consistent values.