### PR TITLE
Fix PSIRT by upgrading go verion from 1.22.4 to 1.24.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/spectrum-virtualize-exporter
 
-go 1.22.4
+go 1.24.13
 
 require (
 	github.com/gorilla/csrf v1.7.1


### PR DESCRIPTION
# Pull Request Info
Fix PSIRT by upgrading go verion from 1.22.4 to 1.24.13

## Change Description

Fix PSIRT by upgrading go verion from 1.22.4 to 1.24.13

## Related Issue

> Provide the issue id related to the PR.

## Test Result

> Provide test methodology, environment, and results if applicable.

- [ ] Unit Test
Tested with prometheus, test passed
- [ ] Integration Test
Tested with Grafana, test passed
