### PR TITLE
Made docker image smaller by using alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,34 @@
-FROM ubuntu:jammy AS pem
-WORKDIR /root/
+# Build stage
+FROM golang:1.22-alpine AS builder
 
+WORKDIR /app
 
-FROM ubuntu:jammy
+# Install git (required for go build with git info)
+RUN apk add --no-cache git
 
-ARG APP_USER=spectrum
+# Copy the entire project
+COPY . .
 
-# Use "make binary" to build the binary spectrum-virtualize-exporter
-COPY spectrum-virtualize-exporter /opt/spectrumVirtualize/spectrum-virtualize-exporter
+# Build the binary with ldflags
+RUN go build -ldflags="-s -w -X github.com/prometheus/common/version.Version=$(git describe --abbrev=0 --tags) \
+    -X github.com/prometheus/common/version.Revision=$(git rev-parse --short HEAD) \
+    -X github.com/prometheus/common/version.Branch=$(git rev-parse --abbrev-ref HEAD) \
+    -X github.com/prometheus/common/version.BuildUser=$(git config user.name | tr -d ' ') \
+    -X github.com/prometheus/common/version.BuildDate=$(TZ=UTC date +%FT%T%z)" \
+    -o spectrum-virtualize-exporter
+
+# Final stage
+FROM alpine:3.23.4
+
+# Install gcompat (required for Go binaries on Alpine)
+RUN apk add --no-cache gcompat
+
+# Copy the binary and config from the builder
+COPY --from=builder /app/spectrum-virtualize-exporter /opt/spectrumVirtualize/spectrum-virtualize-exporter
 COPY spectrumVirtualize.yml /opt/spectrumVirtualize/spectrumVirtualize.yml
 
-RUN groupadd -g 1000 -r $APP_USER \
-    && useradd -u 1000 -r -g $APP_USER -d /home/$APP_USER -m -s /bin/bash $APP_USER \
-    && chown -R 1000:1000 /opt/spectrumVirtualize
-
-USER $APP_USER
-
-# port of prometheus exporter endpoint 
+# Port of Prometheus exporter endpoint
 EXPOSE 9119
 
 ENTRYPOINT ["/opt/spectrumVirtualize/spectrum-virtualize-exporter"]
-CMD ["--config.file=/etc/spectrumVirtualize/spectrumVirtualize.yml"]
+CMD ["--config.file=/opt/spectrumVirtualize/spectrumVirtualize.yml"]

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ binary:
 	go build -ldflags ${ldflags}
 	@echo "build done."
 
-docker: binary
+docker:
 	docker build . -t $(PROJNAME):$(gitCommit)
 
 .PHONY: doc-build


### PR DESCRIPTION
# Pull Request Info

## Change Description

This commit make the docker image smaller (~20MB total) and to build the binary directly from docker

## Related Issue

None

## Test Result

After testing in dev, the exporter seems to work just fine